### PR TITLE
Unuse the flipper lib

### DIFF
--- a/ios/Podfile
+++ b/ios/Podfile
@@ -17,10 +17,10 @@ target 'RNSodiumExample' do
   #
   # Note that if you have use_frameworks! enabled, Flipper will not work and
   # you should disable these next few lines.
-  use_flipper!
-  post_install do |installer|
-    flipper_post_install(installer)
-  end
+  # use_flipper!
+  # post_install do |installer|
+  #   flipper_post_install(installer)
+  # end
 end
 
 target 'RNSodiumExample-tvOS' do


### PR DESCRIPTION
React-native-flipper dependency version compile error issue